### PR TITLE
Tweaked the "draw to figure" function. Now it opens figure editor by …

### DIFF
--- a/easyflow.m
+++ b/easyflow.m
@@ -2439,7 +2439,8 @@ set(fh,'Visible','on');
         %mArgsIn.Display.graph_Yaxis can be 'ylin' or 'ylog'
         mArgsIn=guidata(fh);
         %set up the axis for plotting
-        figure;
+        hFig=figure;
+        plottools(hFig);
         cla(gca);
         hold on;
         switch mArgsIn.Display.graph_type


### PR DESCRIPTION
A little tweak to the "draw to figures" function (in right click menu). Now it opens the figure editor by default. In the past you can open it by one click in the popped out figure, but that button is no longer available in newer version of Matlab. So I just use code to open it by default.